### PR TITLE
Bugfix/distorted pixels

### DIFF
--- a/gfw_pixetl/fixures/sources.yaml
+++ b/gfw_pixetl/fixures/sources.yaml
@@ -994,6 +994,9 @@ umd_tree_cover_density_2000:  # v1.6
         data_type: uint
         nbits: 7
         grids:
+            1/4000:
+                type: raster
+                uri: s3://gfw-files/2018_update/tcd_2000/tiles.geojson
             10/40000:
                 type: raster
                 uri: s3://gfw-files/2018_update/tcd_2000/tiles.geojson

--- a/gfw_pixetl/fixures/sources.yaml
+++ b/gfw_pixetl/fixures/sources.yaml
@@ -969,7 +969,7 @@ umd_tree_cover_loss:  # v1.7
         grids:
             10/40000:
                 type: raster
-                uri: s3://gfw2-data/forest_change/hansen_2019/extent.geojson
+                uri: s3://gfw2-data/forest_change/hansen_2019/tiles.geojson
 #            90/27008:
 #                type: raster
 #                depends_on: umd_tree_cover_loss/year/10/40000

--- a/gfw_pixetl/tiles/raster_src_tile.py
+++ b/gfw_pixetl/tiles/raster_src_tile.py
@@ -284,7 +284,7 @@ class RasterSrcTile(Tile):
         try:
             return vrt.read(
                 window=window,
-                out_shape=(int(round(dst_window.width)), int(round(dst_window.height))),
+                out_shape=(int(round(dst_window.height)), int(round(dst_window.width))),
                 masked=True,
             )
         except rasterio.RasterioIOError:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="gfw_pixetl",
-    version="0.3.0",
+    version="0.3.1",
     description="Tool to preprocess GFW tiles",
     packages=find_packages(exclude=("tests",)),
     author="Thomas Maschler",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Pixels values are off for most output rasters. looks like they are poorly resampled.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- shape for output array for vrt.read were reversed. fix order of width and height to assure, no pixels are distorted
- add additional tests to compare in and output pixel values

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
