### PR TITLE
Rename DB vars to agree with what gfw-data-api exports

### DIFF
--- a/gfw_pixetl/connection.py
+++ b/gfw_pixetl/connection.py
@@ -1,18 +1,18 @@
 from gfw_pixetl.settings.globals import (
-    READER_DBNAME,
-    READER_HOST,
-    READER_PASSWORD,
-    READER_PORT,
-    READER_USERNAME,
+    DB_HOST,
+    DB_NAME,
+    DB_PASSWORD,
+    DB_PORT,
+    DB_USERNAME,
 )
 
 
 class PgConn(object):
-    db_host = READER_HOST
-    db_port = READER_PORT
-    db_name = READER_DBNAME
-    db_user = READER_USERNAME
-    db_password = READER_PASSWORD
+    db_host = DB_HOST
+    db_port = DB_PORT
+    db_name = DB_NAME
+    db_user = DB_USERNAME
+    db_password = DB_PASSWORD
 
     def pg_conn(self):
         return f"PG:dbname={self.db_name} port={self.db_port} host={self.db_host} user={self.db_user} password={self.db_password}"

--- a/gfw_pixetl/settings/globals.py
+++ b/gfw_pixetl/settings/globals.py
@@ -5,13 +5,13 @@ from gfw_pixetl.utils.path import get_aws_s3_endpoint
 from gfw_pixetl.utils.secret import Secret
 from gfw_pixetl.utils.type_casting import to_bool
 
-READER_USERNAME: Optional[str] = os.environ.get("DB_USER_RO", None)
-_password: Optional[str] = os.environ.get("DB_PASSWORD_RO", None)
-READER_PASSWORD: Optional[Secret] = Secret(_password) if _password else None
-READER_HOST: Optional[str] = os.environ.get("DB_HOST_RO", None)
-_port: Optional[str] = os.environ.get("DB_PORT_RO", None)
-READER_PORT: Optional[int] = int(_port) if _port else None
-READER_DBNAME: Optional[str] = os.environ.get("DATABASE_RO", None)
+DB_USERNAME: Optional[str] = os.environ.get("PGUSER", None)
+_password: Optional[str] = os.environ.get("PGPASSWORD", None)
+DB_PASSWORD: Optional[Secret] = Secret(_password) if _password else None
+DB_HOST: Optional[str] = os.environ.get("PGHOST", None)
+_port: Optional[str] = os.environ.get("PGPORT", None)
+DB_PORT: Optional[int] = int(_port) if _port else None
+DB_NAME: Optional[str] = os.environ.get("PGDATABASE", None)
 
 AWS_REGION: str = os.environ.get("AWS_REGION", "us-east-1")
 JOB_ROLE_ARN: Optional[str] = os.environ.get("JOB_ROLE_ARN", None)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the code looks for the following environment variables:
    READER_DBNAME,
     READER_HOST,
     READER_PASSWORD,
     READER_PORT,
     READER_USERNAME,
whereas the gfw-data-api (the primary user of pixetl) most easily exports the following variables instead:
     DB_HOST,
     DB_NAME,
     DB_PASSWORD,
     DB_PORT,
     DB_USERNAME,

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-pixetl will now look for the variable names that it is easiest to export from gfw-data-api.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
I don't think pixetl is actually in use by gfw-data-api yet, so it shouldn't cause a problem. Manual users of pixeetl, however, will need to update their environments. 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
