### PR TITLE
fix tests and make tests compliant with dockerhub

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,9 +1,10 @@
 version: "3"
 
 services:
-  pixetl_test:
+  sut:
     build:
       context: .
+    image: pixetl_test
     container_name: pixetl_test
     volumes:
       - ./gfw_pixetl:/usr/local/app/gfw_pixetl:ro
@@ -27,7 +28,7 @@ services:
       - GOOGLE_APPLICATION_CREDENTIALS=/root/.gcs/private_key.json
       - AWS_GCS_KEY_SECRET_ARN=gcs/gfw-gee-export
     working_dir: /tmp
-    entrypoint: /usr/local/app/wait_for_postgres.sh pytest -vv --cov-report term --cov-report xml:/usr/local/app/tests/cobertura.xml --cov=gfw_pixetl
+    entrypoint: /usr/local/app/wait_for_postgres.sh pytest -vv --cov-report term --cov-report xml:/usr/local/app/tests/cobertura.xml --cov=gfw_pixetl /usr/local/app/tests/
     depends_on:
       - test_database
       - motoserver

--- a/scripts/test
+++ b/scripts/test
@@ -26,11 +26,13 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 
 
 if [ "${BUILD}" = true ]; then
-  docker-compose -f docker-compose.test.yml --project-name gfw-pixetl_test build pixetl_test
+  docker-compose -f docker-compose.test.yml --project-name gfw-pixetl_test build sut
 fi
 
 set +e
-docker-compose -f docker-compose.test.yml --project-name gfw-pixetl_test run --rm --name pixetl_test pixetl_test /usr/local/app/tests/"$*"
+docker-compose -f docker-compose.test.yml --project-name gfw-pixetl_test run --rm --name pixetl_test \
+              --entrypoint "pytest -vv --cov-report term --cov-report xml:/usr/local/app/tests/cobertura.xml --cov=gfw_pixetl" \
+               sut /usr/local/app/tests/"$*"
 exit_code=$?
 docker-compose -f docker-compose.test.yml --project-name gfw-pixetl_test down --remove-orphans
 exit $exit_code

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -183,7 +183,7 @@ def test_gradient_symbology():
     assert tile.local_dst[tile.default_format].profile["count"] == 1
 
     tile.add_symbology()
-    sleep(60)
+    # sleep(60)
     assert (
         os.path.basename(tile.local_dst[tile.default_format].uri)
         == f"{tile.tile_id}_colored.tif"
@@ -224,7 +224,7 @@ def test_discrete_symbology():
 
     tile = Tile("01N_001E", layer.grid, layer)
 
-    test_file = os.path.join(TILE.tmp_dir, "test_discrete_color.tif")
+    test_file = os.path.join(TILE.tmp_dir, "test_gradient_color.tif")
     shutil.copyfile(TILE_4_PATH, test_file)
 
     # monkey patch method to point to test file
@@ -233,23 +233,19 @@ def test_discrete_symbology():
     tile.set_local_dst(tile.default_format)
 
     assert tile.local_dst[tile.default_format].profile["count"] == 1
-    with rasterio.open(tile.local_dst[tile.default_format].uri) as src, pytest.raises(
-        ValueError
-    ):
-        src.colormap(1)
 
     tile.add_symbology()
-
-    assert tile.local_dst[tile.default_format].uri == test_file
-    assert tile.local_dst[tile.default_format].profile["count"] == 1
-
-    _colormap = layer.symbology.colormap
-    colormap = {0: (0, 0, 0, 0)}
-    for pixel_value in _colormap:
-        colormap[int(pixel_value)] = tuple(_colormap[pixel_value].dict().values())
-
-    for i in range(6, 256):
-        colormap[i] = (0, 0, 0, 255)
-
-    with rasterio.open(tile.local_dst[tile.default_format].uri) as src:
-        assert src.colormap(1) == colormap
+    # sleep(60)
+    assert (
+        os.path.basename(tile.local_dst[tile.default_format].uri)
+        == f"{tile.tile_id}_colored.tif"
+    )
+    assert tile.local_dst[tile.default_format].profile["count"] == 4
+    assert (
+        tile.local_dst[tile.default_format].blockxsize
+        == layer.dst_profile["blockxsize"]
+    )
+    assert (
+        tile.local_dst[tile.default_format].blockysize
+        == layer.dst_profile["blockysize"]
+    )


### PR DESCRIPTION
Signed-off-by: Thomas Maschler <tmaschler@wri.org>

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 
-gdal2tiles cannot use colormap tiles. It always requires RGBA tiles


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- use gdaldem to compute RBGA image for discrete colormap
-
-

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
Output for discrete colormap tiles in now also an RGBA image

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

