### PR TITLE
Put gdalinfo output in exception msg

### DIFF
--- a/gfw_pixetl/utils/gdal.py
+++ b/gfw_pixetl/utils/gdal.py
@@ -137,16 +137,24 @@ def get_metadata(
             blockysize=band["block"][1],
         )
 
-        if compute_stats:
-            band_metadata.stats = BandStats(
-                min=band["minimum"],
-                max=band["maximum"],
-                mean=band["mean"],
-                std_dev=band["stdDev"],
-            )
-        if compute_histogram:
-            band_metadata.histogram = Histogram(**band["histogram"])
+        try:
+            if compute_stats:
+                band_metadata.stats = BandStats(
+                    min=band["minimum"],
+                    max=band["maximum"],
+                    mean=band["mean"],
+                    std_dev=band["stdDev"],
+                )
+            if compute_histogram:
+                band_metadata.histogram = Histogram(**band["histogram"])
 
-        metadata.bands.append(band_metadata)
+            metadata.bands.append(band_metadata)
+        except KeyError:
+            msg = (
+                "Caught KeyError exception. Complete output for command "
+                f"[ {cmd} ]: {json.dumps(meta, indent=2)}"
+            )
+            LOGGER.error(msg)
+            raise Exception(msg)
 
     return metadata

--- a/gfw_pixetl/utils/gdal.py
+++ b/gfw_pixetl/utils/gdal.py
@@ -149,12 +149,12 @@ def get_metadata(
                 band_metadata.histogram = Histogram(**band["histogram"])
 
             metadata.bands.append(band_metadata)
-        except KeyError:
+        except Exception:
             msg = (
-                "Caught KeyError exception. Complete output for command "
+                "Caught exception. Complete output for command "
                 f"[ {cmd} ]: {json.dumps(meta, indent=2)}"
             )
-            LOGGER.error(msg)
+            LOGGER.exception(msg)
             raise Exception(msg)
 
     return metadata


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): 
Increased transparency on gdalinfo errors

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Sometimes calculating statistics/histograms fails. When it does so, the error message we get is useless
Issue Number: GTC-937


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Put the entire gdalinfo output in the exception body so we can see it
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
