### PR TITLE
Tolerate empty tiles when generating stats/histograms; fix no_data for float data

### DIFF
--- a/gfw_pixetl/data_type.py
+++ b/gfw_pixetl/data_type.py
@@ -57,7 +57,7 @@ class DataType(object):
         elif (
             ("float" in dtype or dtype in ["half", "single", "double"])
             and (no_data is not None)
-            and (type(no_data) != float)
+            and (not isinstance(no_data, float))
         ):
             message = f"No data value {no_data} must be of type `float` or None for data type {data_type}"
             raise ValueError(message)

--- a/gfw_pixetl/data_type.py
+++ b/gfw_pixetl/data_type.py
@@ -2,6 +2,8 @@ import math
 from enum import Enum
 from typing import Callable, Dict, Optional, Union
 
+from pydantic.types import StrictFloat, StrictInt
+
 from gfw_pixetl import get_module_logger
 
 LOGGER = get_module_logger(__name__)
@@ -27,14 +29,14 @@ class DataType(object):
     def __init__(
         self,
         data_type: str,
-        no_data: Optional[Union[int, float]],
-        nbits: Optional[int] = None,
+        no_data: Optional[Union[StrictInt, StrictFloat]],
+        nbits: Optional[StrictInt] = None,
         compression: str = "DEFLATE",
     ) -> None:
         self._validate_no_data(data_type, no_data, nbits)
         self.data_type: str = data_type
-        self.no_data: Optional[Union[int, float]] = no_data
-        self.nbits: Optional[int] = nbits
+        self.no_data: Optional[Union[StrictInt, StrictFloat]] = no_data
+        self.nbits: Optional[StrictInt] = nbits
         self.compression: str = compression
 
         if data_type == "int8":
@@ -47,7 +49,9 @@ class DataType(object):
 
     @staticmethod
     def _validate_no_data(
-        data_type: str, no_data: Optional[Union[int, float]], nbits: Optional[int]
+        data_type: str,
+        no_data: Optional[Union[StrictInt, StrictFloat]],
+        nbits: Optional[StrictInt],
     ):
         dtype = data_type.lower()
 
@@ -84,7 +88,7 @@ def data_type_constructor(
 def data_type_factory(
     data_type: str,
     nbits: Optional[int] = None,
-    no_data: Optional[Union[int, float]] = None,
+    no_data: Optional[Union[StrictInt, StrictFloat]] = None,
 ) -> DataType:
     _8bits: Optional[int] = None if not nbits or nbits not in range(1, 8) else nbits
     _16bits: Optional[int] = None if not nbits or nbits not in range(9, 16) else nbits

--- a/gfw_pixetl/data_type.py
+++ b/gfw_pixetl/data_type.py
@@ -2,7 +2,7 @@ import math
 from enum import Enum
 from typing import Callable, Dict, Optional, Union
 
-from pydantic.types import StrictFloat, StrictInt
+from pydantic.types import StrictInt
 
 from gfw_pixetl import get_module_logger
 
@@ -29,13 +29,13 @@ class DataType(object):
     def __init__(
         self,
         data_type: str,
-        no_data: Optional[Union[StrictInt, StrictFloat]],
+        no_data: Optional[Union[StrictInt, float]],
         nbits: Optional[StrictInt] = None,
         compression: str = "DEFLATE",
     ) -> None:
         self._validate_no_data(data_type, no_data, nbits)
         self.data_type: str = data_type
-        self.no_data: Optional[Union[StrictInt, StrictFloat]] = no_data
+        self.no_data: Optional[Union[StrictInt, float]] = no_data
         self.nbits: Optional[StrictInt] = nbits
         self.compression: str = compression
 
@@ -50,7 +50,7 @@ class DataType(object):
     @staticmethod
     def _validate_no_data(
         data_type: str,
-        no_data: Optional[Union[StrictInt, StrictFloat]],
+        no_data: Optional[Union[StrictInt, float]],
         nbits: Optional[StrictInt],
     ):
         dtype = data_type.lower()
@@ -88,7 +88,7 @@ def data_type_constructor(
 def data_type_factory(
     data_type: str,
     nbits: Optional[int] = None,
-    no_data: Optional[Union[StrictInt, StrictFloat]] = None,
+    no_data: Optional[Union[StrictInt, float]] = None,
 ) -> DataType:
     _8bits: Optional[int] = None if not nbits or nbits not in range(1, 8) else nbits
     _16bits: Optional[int] = None if not nbits or nbits not in range(9, 16) else nbits

--- a/gfw_pixetl/data_type.py
+++ b/gfw_pixetl/data_type.py
@@ -54,8 +54,10 @@ class DataType(object):
         if "int" in dtype and (no_data is not None and not isinstance(no_data, int)):
             message = f"No data value {no_data} must be of type `int` or None for data type {data_type}"
             raise ValueError(message)
-        elif ("float" in dtype or dtype in ["half", "single", "double"]) and (
-            no_data is not None and not math.isnan(no_data)
+        elif (
+            ("float" in dtype or dtype in ["half", "single", "double"])
+            and (no_data is not None)
+            and (type(no_data) != float)
         ):
             message = f"No data value {no_data} must be of type `float` or None for data type {data_type}"
             raise ValueError(message)

--- a/gfw_pixetl/data_type.py
+++ b/gfw_pixetl/data_type.py
@@ -2,6 +2,7 @@ import math
 from enum import Enum
 from typing import Callable, Dict, Optional, Union
 
+import numpy as np
 from pydantic.types import StrictInt
 
 from gfw_pixetl import get_module_logger
@@ -59,7 +60,8 @@ class DataType(object):
             message = f"No data value {no_data} must be of type `int` or None for data type {data_type}"
             raise ValueError(message)
         elif (
-            ("float" in dtype or dtype in ["half", "single", "double"])
+            getattr(DataTypeEnum, dtype, None) is not None
+            and np.issubdtype(np.dtype(dtype), np.floating)
             and (no_data is not None)
             and (not isinstance(no_data, float))
         ):

--- a/gfw_pixetl/grids/grid_factory.py
+++ b/gfw_pixetl/grids/grid_factory.py
@@ -3,11 +3,10 @@ from typing import Dict
 from gfw_pixetl import get_module_logger
 
 from . import Grid
-
-LOGGER = get_module_logger(__name__)
-
 from .lat_lng_grid import LatLngGrid
 from .wm_grid import WebMercatorGrid
+
+LOGGER = get_module_logger(__name__)
 
 
 def grid_factory(grid_name) -> Grid:
@@ -15,7 +14,7 @@ def grid_factory(grid_name) -> Grid:
 
     grids: Dict[str, Grid] = {
         "1/4000": LatLngGrid(1, 4000),  # TEST grid
-        "3/33600": LatLngGrid(3, 33600),  # RAAD alerts, ~10m pixel
+        "3/33600": LatLngGrid(3, 33600),  # RADD alerts, ~10m pixel
         "10/40000": LatLngGrid(10, 40000),  # UMD alerts, ~30m pixel
         "8/32000": LatLngGrid(
             8, 32000

--- a/gfw_pixetl/layers.py
+++ b/gfw_pixetl/layers.py
@@ -83,7 +83,7 @@ class Layer(object):
             "blockxsize": grid.blockxsize,
             "blockysize": grid.blockysize,
             "pixeltype": "SIGNEDBYTE" if data_type.signed_byte else "DEFAULT",
-            "nodata": int(data_type.no_data) if data_type.no_data is not None else None,
+            "nodata": data_type.no_data,
         }
 
         if data_type.nbits:

--- a/gfw_pixetl/models.py
+++ b/gfw_pixetl/models.py
@@ -74,17 +74,17 @@ class LayerModel(BaseModel):
 
 
 class Histogram(BaseModel):
-    count: int
-    min: float
-    max: float
-    buckets: List[int]
+    count: Optional[int]
+    min: Optional[float]
+    max: Optional[float]
+    buckets: Optional[List[int]]
 
 
 class BandStats(BaseModel):
-    min: float
-    max: float
-    mean: float
-    std_dev: float
+    min: Optional[float]
+    max: Optional[float]
+    mean: Optional[float]
+    std_dev: Optional[float]
 
 
 class Band(BaseModel):

--- a/gfw_pixetl/models.py
+++ b/gfw_pixetl/models.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
-from pydantic import BaseModel, Field, StrictFloat, StrictInt
+from pydantic import BaseModel, Field, StrictInt
 from shapely.geometry import MultiPolygon, Polygon
 
 from gfw_pixetl.data_type import DataTypeEnum
@@ -10,7 +10,7 @@ from gfw_pixetl.resampling import ResamplingMethodEnum
 VERSION_REGEX = r"^v\d{1,8}\.?\d{,3}\.?\d{,3}$"
 
 Bounds = Tuple[float, float, float, float]
-OrderedColorMap = Dict[Union[StrictInt, StrictFloat], Tuple[int, int, int, int]]
+OrderedColorMap = Dict[Union[StrictInt, float], Tuple[int, int, int, int]]
 FeatureTuple = Sequence[Tuple[Union[Polygon, MultiPolygon], Optional[Dict[str, Any]]]]
 
 
@@ -51,7 +51,7 @@ class RGBA(BaseModel):
 
 class Symbology(BaseModel):
     type: ColorMapType
-    colormap: Dict[Union[StrictInt, StrictFloat], RGBA]
+    colormap: Dict[Union[StrictInt, float], RGBA]
 
 
 class LayerModel(BaseModel):
@@ -61,7 +61,7 @@ class LayerModel(BaseModel):
     pixel_meaning: str
     data_type: DataTypeEnum
     nbits: Optional[int]
-    no_data: Optional[Union[StrictInt, StrictFloat]]
+    no_data: Optional[Union[StrictInt, float]]
     grid: str  # Make an enum?
     rasterize_method: Optional[RasterizeMethod]
     resampling: ResamplingMethodEnum = ResamplingMethodEnum.nearest
@@ -89,7 +89,7 @@ class BandStats(BaseModel):
 
 class Band(BaseModel):
     data_type: DataTypeEnum
-    no_data: Optional[Union[StrictInt, StrictFloat]]
+    no_data: Optional[Union[StrictInt, float]]
     nbits: Optional[int]
     blockxsize: int
     blockysize: int

--- a/gfw_pixetl/models.py
+++ b/gfw_pixetl/models.py
@@ -10,7 +10,7 @@ from gfw_pixetl.resampling import ResamplingMethodEnum
 VERSION_REGEX = r"^v\d{1,8}\.?\d{,3}\.?\d{,3}$"
 
 Bounds = Tuple[float, float, float, float]
-OrderedColorMap = Dict[Union[int, float], Tuple[int, int, int, int]]
+OrderedColorMap = Dict[Union[StrictInt, StrictFloat], Tuple[int, int, int, int]]
 FeatureTuple = Sequence[Tuple[Union[Polygon, MultiPolygon], Optional[Dict[str, Any]]]]
 
 
@@ -89,7 +89,7 @@ class BandStats(BaseModel):
 
 class Band(BaseModel):
     data_type: DataTypeEnum
-    no_data: Optional[Union[int, float]]
+    no_data: Optional[Union[StrictInt, StrictFloat]]
     nbits: Optional[int]
     blockxsize: int
     blockysize: int

--- a/gfw_pixetl/models.py
+++ b/gfw_pixetl/models.py
@@ -74,17 +74,17 @@ class LayerModel(BaseModel):
 
 
 class Histogram(BaseModel):
-    count: Optional[int]
-    min: Optional[float]
-    max: Optional[float]
-    buckets: Optional[List[int]]
+    count: int
+    min: float
+    max: float
+    buckets: List[int]
 
 
 class BandStats(BaseModel):
-    min: Optional[float]
-    max: Optional[float]
-    mean: Optional[float]
-    std_dev: Optional[float]
+    min: float
+    max: float
+    mean: float
+    std_dev: float
 
 
 class Band(BaseModel):

--- a/gfw_pixetl/models.py
+++ b/gfw_pixetl/models.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StrictFloat, StrictInt
 from shapely.geometry import MultiPolygon, Polygon
 
 from gfw_pixetl.data_type import DataTypeEnum
@@ -51,7 +51,7 @@ class RGBA(BaseModel):
 
 class Symbology(BaseModel):
     type: ColorMapType
-    colormap: Dict[Union[int, float], RGBA]
+    colormap: Dict[Union[StrictInt, StrictFloat], RGBA]
 
 
 class LayerModel(BaseModel):
@@ -61,7 +61,7 @@ class LayerModel(BaseModel):
     pixel_meaning: str
     data_type: DataTypeEnum
     nbits: Optional[int]
-    no_data: Optional[Union[int, float]]
+    no_data: Optional[Union[StrictInt, StrictFloat]]
     grid: str  # Make an enum?
     rasterize_method: Optional[RasterizeMethod]
     resampling: ResamplingMethodEnum = ResamplingMethodEnum.nearest

--- a/gfw_pixetl/sources.py
+++ b/gfw_pixetl/sources.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional, Tuple, Union
 
 import rasterio
 from numpy import dtype as ndtype
-from pydantic.types import StrictFloat, StrictInt
+from pydantic.types import StrictInt
 from pyproj import CRS, Transformer
 from rasterio.coords import BoundingBox
 from rasterio.crs import CRS as rCRS
@@ -98,11 +98,11 @@ class Raster(Source):
         self.profile["width"] = v
 
     @property
-    def nodata(self) -> Optional[Union[StrictInt, StrictFloat]]:
+    def nodata(self) -> Optional[Union[StrictInt, float]]:
         return self.profile["nodata"] if "nodata" in self.profile.keys() else None
 
     @nodata.setter
-    def nodata(self, v: Union[StrictInt, StrictFloat]) -> None:
+    def nodata(self, v: Union[StrictInt, float]) -> None:
         self.profile["nodata"] = v
 
     @property

--- a/gfw_pixetl/sources.py
+++ b/gfw_pixetl/sources.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional, Tuple, Union
 
 import rasterio
 from numpy import dtype as ndtype
+from pydantic.types import StrictFloat, StrictInt
 from pyproj import CRS, Transformer
 from rasterio.coords import BoundingBox
 from rasterio.crs import CRS as rCRS
@@ -97,11 +98,11 @@ class Raster(Source):
         self.profile["width"] = v
 
     @property
-    def nodata(self) -> Optional[Union[int, float]]:
+    def nodata(self) -> Optional[Union[StrictInt, StrictFloat]]:
         return self.profile["nodata"] if "nodata" in self.profile.keys() else None
 
     @nodata.setter
-    def nodata(self, v: Union[int, float]) -> None:
+    def nodata(self, v: Union[StrictInt, StrictFloat]) -> None:
         self.profile["nodata"] = v
 
     @property

--- a/gfw_pixetl/tiles/tile.py
+++ b/gfw_pixetl/tiles/tile.py
@@ -5,6 +5,7 @@ from abc import ABC
 from typing import Dict, Union
 
 import rasterio
+from pydantic.types import StrictFloat, StrictInt
 from rasterio.coords import BoundingBox
 from rasterio.crs import CRS
 from rasterio.shutil import copy as raster_copy
@@ -241,7 +242,7 @@ class Tile(ABC):
 
         """
         assert self.layer.symbology, "No colormap specified."
-        colormap: Dict[Union[int, float], RGBA] = copy.deepcopy(
+        colormap: Dict[Union[StrictInt, StrictFloat], RGBA] = copy.deepcopy(
             self.layer.symbology.colormap
         )
 

--- a/gfw_pixetl/tiles/tile.py
+++ b/gfw_pixetl/tiles/tile.py
@@ -5,7 +5,7 @@ from abc import ABC
 from typing import Dict, Union
 
 import rasterio
-from pydantic.types import StrictFloat, StrictInt
+from pydantic.types import StrictInt
 from rasterio.coords import BoundingBox
 from rasterio.crs import CRS
 from rasterio.shutil import copy as raster_copy
@@ -242,7 +242,7 @@ class Tile(ABC):
 
         """
         assert self.layer.symbology, "No colormap specified."
-        colormap: Dict[Union[StrictInt, StrictFloat], RGBA] = copy.deepcopy(
+        colormap: Dict[Union[StrictInt, float], RGBA] = copy.deepcopy(
             self.layer.symbology.colormap
         )
 

--- a/gfw_pixetl/utils/gdal.py
+++ b/gfw_pixetl/utils/gdal.py
@@ -137,25 +137,16 @@ def get_metadata(
             blockysize=band["block"][1],
         )
 
-        try:
-            if compute_stats:
-                band_metadata.stats = BandStats(
-                    min=band["minimum"],
-                    max=band["maximum"],
-                    mean=band["mean"],
-                    std_dev=band["stdDev"],
-                )
-            if compute_histogram:
-                band_metadata.histogram = Histogram(**band["histogram"])
-
-            metadata.bands.append(band_metadata)
-        except Exception as ex:
-            # Don't bother logging because this happens in a sub-process and
-            # won't be seen. But the msg of an exception DOES make it back,
-            # so put something informative in there.
-            msg = (
-                f"Caught exception running {cmd} stdout: {o} stderr: {e} exception:{ex}"
+        if compute_stats:
+            band_metadata.stats = BandStats(
+                min=band.get("minimum"),
+                max=band.get("maximum"),
+                mean=band.get("mean"),
+                std_dev=band.get("stdDev"),
             )
-            raise Exception(msg)
+        if compute_histogram:
+            band_metadata.histogram = Histogram(**band.get("histogram", dict()))
+
+        metadata.bands.append(band_metadata)
 
     return metadata

--- a/gfw_pixetl/utils/gdal.py
+++ b/gfw_pixetl/utils/gdal.py
@@ -138,14 +138,23 @@ def get_metadata(
         )
 
         if compute_stats:
-            band_metadata.stats = BandStats(
-                min=band.get("minimum"),
-                max=band.get("maximum"),
-                mean=band.get("mean"),
-                std_dev=band.get("stdDev"),
-            )
+            # For some empty tiles generating stats fails
+            try:
+                band_metadata.stats = BandStats(
+                    min=band["minimum"],
+                    max=band["maximum"],
+                    mean=band["mean"],
+                    std_dev=band["stdDev"],
+                )
+            except KeyError:
+                pass
+
         if compute_histogram:
-            band_metadata.histogram = Histogram(**band.get("histogram", dict()))
+            # For some empty tiles generating histogram fails
+            try:
+                band_metadata.histogram = Histogram(**band["histogram"])
+            except KeyError:
+                pass
 
         metadata.bands.append(band_metadata)
 

--- a/gfw_pixetl/utils/gdal.py
+++ b/gfw_pixetl/utils/gdal.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from retrying import retry
 
 from gfw_pixetl import get_module_logger
-from gfw_pixetl.data_type import from_gdal_data_type
+from gfw_pixetl.data_type import DataTypeEnum, from_gdal_data_type
 from gfw_pixetl.errors import (
     GDALAWSConfigError,
     GDALError,
@@ -131,7 +131,7 @@ def get_metadata(
 
         band_metadata = Band(
             no_data=band.get("noDataValue", None),
-            data_type=from_gdal_data_type(band["type"]),
+            data_type=DataTypeEnum(from_gdal_data_type(band["type"])),
             nbits=band["metadata"].get("IMAGE_STRUCTURE", dict()).get("NBITS", None),
             blockxsize=band["block"][0],
             blockysize=band["block"][1],

--- a/gfw_pixetl/utils/upload_geometries.py
+++ b/gfw_pixetl/utils/upload_geometries.py
@@ -135,12 +135,13 @@ def _union_tile_geoms(fc: FeatureCollection) -> FeatureCollection:
 
 
 def _sanitize_props(props: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    # Non-numeric float values (like NaN) are not JSON-legal
     if props is None:
         return None
     for band in props.get("bands", dict()):
         no_data = band.get("no_data")
         if no_data is not None and math.isnan(no_data):
-            band["no_data"] = "NaN"
+            band["no_data"] = "nan"
     return props
 
 

--- a/gfw_pixetl/utils/upload_geometries.py
+++ b/gfw_pixetl/utils/upload_geometries.py
@@ -1,7 +1,8 @@
 import json
+import math
 import os
 from copy import deepcopy
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from botocore.exceptions import ClientError
 from geojson import Feature, FeatureCollection, dumps
@@ -60,7 +61,7 @@ def upload_geojsons(
 def _merge_feature_collections(
     fc: FeatureCollection, bucket: str, key: str
 ) -> FeatureCollection:
-    """Add existing tiles to from S3 to Feature Collection.
+    """Add existing tiles from S3 to Feature Collection.
 
     This will allow us to skip computing stats and histogram for already
     processed tiles. We assume here that tiles.json represents all
@@ -133,11 +134,21 @@ def _union_tile_geoms(fc: FeatureCollection) -> FeatureCollection:
     return _to_feature_collection([(extent, None)])
 
 
+def _sanitize_props(props: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if props is None:
+        return None
+    for band in props.get("bands", dict()):
+        no_data = band.get("no_data")
+        if no_data is not None and math.isnan(no_data):
+            band["no_data"] = "NaN"
+    return props
+
+
 def _to_feature_collection(geoms: FeatureTuple) -> FeatureCollection:
     """Convert list of features to feature collection."""
 
     features: List[Feature] = [
-        Feature(geometry=item[0], properties=item[1]) for item in geoms
+        Feature(geometry=item[0], properties=_sanitize_props(item[1])) for item in geoms
     ]
     return FeatureCollection(features)
 

--- a/terraform/batchjobs.tf
+++ b/terraform/batchjobs.tf
@@ -1,11 +1,11 @@
 resource "aws_batch_job_definition" "default" {
-  name                 = "${local.project}${local.name_suffix}"
+  name                 = replace("${local.project}${local.name_suffix}", ".", "_")
   type                 = "container"
   container_properties = data.template_file.container_properties.rendered
 }
 
 resource "aws_batch_job_queue" "default" {
-  name                 = "${local.project}-job-queue${local.name_suffix}"
+  name                 = replace("${local.project}-job-queue${local.name_suffix}", ".", "_")
   state                = "ENABLED"
   priority             = 1
   compute_environments = [module.compute_environment_ephemeral_storage.arn]

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -68,9 +68,12 @@ def test_no_data():
     data_type = data_type_factory("float32", no_data=0.0)
     assert data_type.no_data == 0.0
 
-    # FIXME: Surely this test is wrong?
+    # Note: Surely this test is wrong? Ask Thomas.
     # with pytest.raises(ValueError):
     #     data_type_factory("float32", no_data=1.1)
+    # Surely this should be the correct behavior
+    data_type = data_type_factory("float32", no_data=1.1)
+    assert data_type.no_data == 1.1
 
     with pytest.raises(ValueError):
         data_type_factory("float32", no_data=1)

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -3,12 +3,7 @@ import os
 
 import pytest
 
-from gfw_pixetl.data_type import (
-    DataType,
-    DataTypeEnum,
-    data_type_factory,
-    to_gdal_data_type,
-)
+from gfw_pixetl.data_type import DataType, DataTypeEnum, data_type_factory
 
 os.environ["ENV"] = "test"
 
@@ -70,8 +65,12 @@ def test_no_data():
     data_type = data_type_factory("float32", no_data=math.nan)
     assert math.isnan(data_type.no_data)
 
-    with pytest.raises(ValueError):
-        data_type_factory("float32", no_data=1.1)
+    data_type = data_type_factory("float32", no_data=0.0)
+    assert data_type.no_data == 0.0
+
+    # FIXME: Surely this test is wrong?
+    # with pytest.raises(ValueError):
+    #     data_type_factory("float32", no_data=1.1)
 
     with pytest.raises(ValueError):
         data_type_factory("float32", no_data=1)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -97,3 +97,36 @@ def test_layer_model():
     resampling = resampling_factory(layer_def.resampling)
 
     assert resampling == Resampling.bilinear
+
+
+def test_layer_model_floats():
+    layer_def = LayerModel(
+        dataset="test",
+        version="v1.1.1",
+        source_type="raster",
+        pixel_meaning="test",
+        data_type=DataTypeEnum.float32,
+        nbits=6,
+        grid="10/40000",
+        resampling="bilinear",
+        source_uri="s3://test/tiles.geojson",
+        no_data="nan",
+    )
+
+    assert isinstance(layer_def.no_data, float)
+    assert math.isnan(layer_def.no_data)
+
+    layer_def = LayerModel(
+        dataset="test",
+        version="v1.1.1",
+        source_type="raster",
+        pixel_meaning="test",
+        data_type=DataTypeEnum.float32,
+        nbits=6,
+        grid="10/40000",
+        resampling="bilinear",
+        source_uri="s3://test/tiles.geojson",
+        no_data="2.2",
+    )
+
+    assert isinstance(layer_def.no_data, float)

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -1,17 +1,11 @@
 import os
 import shutil
-from copy import deepcopy
-from time import sleep
 from typing import Any, Dict, Optional
 from unittest import mock
-from unittest.mock import patch
 
 import numpy as np
-import pytest
-import rasterio
 from rasterio import Affine
 from rasterio.crs import CRS
-from rasterio.enums import ColorInterp
 from rasterio.windows import Window
 from shapely.geometry import box
 
@@ -21,7 +15,7 @@ from gfw_pixetl.sources import RasterSource
 from gfw_pixetl.tiles import Tile
 from gfw_pixetl.utils.aws import get_s3_client
 from tests import minimal_layer_dict
-from tests.conftest import BUCKET, TILE_1_PATH, TILE_4_PATH
+from tests.conftest import BUCKET, TILE_4_PATH
 
 os.environ["ENV"] = "test"
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Importing a raster tile set with compute_stats or compute_histogram fails
- Automatic build + deployment to Dockerhub fails
- Importing a float dataset with a float no_data value fails

Issue Number: GTC-937


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Importing a raster tile set with compute_stats or compute_histogram succeeds
- Deploying pixetl to Dockerhub succeeds
- Importing a float dataset with a float no_data value succeeds

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
