### PR TITLE
use second motoserver for secretsmanager

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -42,18 +42,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:38f503f0502aba4251dff4d19057c31a7b9dd0f54333df5521f8931ee4c65e26",
-                "sha256:8343a8e87c07cfebd1ca26b21b841f0875f28622e9a08e8dd2d1085881f9a6fd"
+                "sha256:a280123db79e73478bd23933486f3a0ffa2397d1a6381f32573f2731ff48c59a",
+                "sha256:bb91fecf982e1bbfb68bb6bd2c9a0cce3c84ac6f97dd338d1ef9e47780679091"
             ],
             "index": "pypi",
-            "version": "==1.16.61"
+            "version": "==1.16.62"
         },
         "botocore": {
             "hashes": [
-                "sha256:3245c9e996143bcfdea73d105145ca733fcd7d5afe744a8760612fc449c3f810",
-                "sha256:59da7b91ebd57362b482d3963392f2944296d6dc79877bf716e1c2671a208a74"
+                "sha256:1046c152e5865aabbe6b10b2d33e652b3dd072516f3976e96cacc6b7c4460d02",
+                "sha256:29b4b9be5b40f392a033926c08c004c01bd6471384ef6f12eaa49ee3870a010c"
             ],
-            "version": "==1.19.61"
+            "version": "==1.19.62"
         },
         "cachetools": {
             "hashes": [
@@ -709,18 +709,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:38f503f0502aba4251dff4d19057c31a7b9dd0f54333df5521f8931ee4c65e26",
-                "sha256:8343a8e87c07cfebd1ca26b21b841f0875f28622e9a08e8dd2d1085881f9a6fd"
+                "sha256:a280123db79e73478bd23933486f3a0ffa2397d1a6381f32573f2731ff48c59a",
+                "sha256:bb91fecf982e1bbfb68bb6bd2c9a0cce3c84ac6f97dd338d1ef9e47780679091"
             ],
             "index": "pypi",
-            "version": "==1.16.61"
+            "version": "==1.16.62"
         },
         "botocore": {
             "hashes": [
-                "sha256:3245c9e996143bcfdea73d105145ca733fcd7d5afe744a8760612fc449c3f810",
-                "sha256:59da7b91ebd57362b482d3963392f2944296d6dc79877bf716e1c2671a208a74"
+                "sha256:1046c152e5865aabbe6b10b2d33e652b3dd072516f3976e96cacc6b7c4460d02",
+                "sha256:29b4b9be5b40f392a033926c08c004c01bd6471384ef6f12eaa49ee3870a010c"
             ],
-            "version": "==1.19.61"
+            "version": "==1.19.62"
         },
         "certifi": {
             "hashes": [

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -23,17 +23,19 @@ services:
       - AWS_SECRET_ACCESS_KEY=testing  # pragma: allowlist secret
       - AWS_SECURITY_TOKEN=testing  # pragma: allowlist secret
       - AWS_SESSION_TOKEN=testing  # pragma: allowlist secret
-      - AWS_ENDPOINT_URL=http://motoserver:5000
+      - AWS_ENDPOINT_URL=http://motoserver-s3:5000
+      - AWS_SECRETSMANAGER_URL=http://motoserver-secretsmanager:5001
       - AWS_HTTPS=NO
       - AWS_VIRTUAL_HOSTING=FALSE
       - GDAL_DISABLE_READDIR_ON_OPEN=YES
       - GOOGLE_APPLICATION_CREDENTIALS=/root/.gcs/private_key.json
       - AWS_GCS_KEY_SECRET_ARN=gcs/gfw-gee-export
     working_dir: /tmp
-    entrypoint: /usr/local/app/wait_for_postgres.sh pytest -vv --cov-report term --cov-report xml:/usr/local/app/tests/cobertura.xml --cov=gfw_pixetl
+    entrypoint: /usr/local/app/tests/run_tests.sh
     depends_on:
       - test_database
-      - motoserver
+      - motoserver-s3
+      - motoserver-secretsmanager
 
   test_database:
     container_name: pixetl-test-database
@@ -49,12 +51,20 @@ services:
       - test_database_data:/var/lib/postgresql/data
     restart: on-failure
 
-  motoserver:
-    container_name: motoserver
+  motoserver-s3:
+    container_name: motoserver-s3
     image: motoserver/moto:latest
     ports:
       - 5000:5000
-    entrypoint: moto_server s3 -H 0.0.0.0
+    entrypoint: moto_server s3 -p 5000 -H 0.0.0.0
+    restart: on-failure
+
+  motoserver-secretsmanager:
+    container_name: motoserver-secretsmanager
+    image: motoserver/moto:latest
+    ports:
+      - 5001:5001
+    entrypoint: moto_server secretsmanager -p 5001 -H 0.0.0.0
     restart: on-failure
 
 volumes:

--- a/gfw_pixetl/errors.py
+++ b/gfw_pixetl/errors.py
@@ -73,7 +73,7 @@ def retry_if_missing_gcs_key_error(exception) -> bool:
         and GDAL_ENV.get("GOOGLE_APPLICATION_CREDENTIALS")
         and GLOBALS.aws_gcs_key_secret_arn
     ):
-        set_google_application_credentials()
+        set_google_application_credentials(GDAL_ENV["GOOGLE_APPLICATION_CREDENTIALS"])
 
     elif is_missing_gcs_key_error and (
         not GDAL_ENV["GOOGLE_APPLICATION_CREDENTIALS"]

--- a/gfw_pixetl/pixetl.py
+++ b/gfw_pixetl/pixetl.py
@@ -12,9 +12,11 @@ from gfw_pixetl.layers import Layer, layer_factory
 from gfw_pixetl.logo import logo
 from gfw_pixetl.models.pydantic import LayerModel
 from gfw_pixetl.pipes import Pipe, pipe_factory
+from gfw_pixetl.settings.gdal import (  # noqa: F401, import vars to assure they are initialize right in the beginning
+    GDAL_ENV,
+)
 from gfw_pixetl.tiles import Tile
 from gfw_pixetl.utils.cwd import remove_work_directory, set_cwd
-from gfw_pixetl.utils.secrets import set_google_application_credentials
 
 LOGGER = get_module_logger(__name__)
 
@@ -92,9 +94,6 @@ def pixetl(
 
     old_cwd = os.getcwd()
     cwd = set_cwd()
-
-    # Make sure google application credentials are correctly set
-    set_google_application_credentials()
 
     # set available memory here before any major process is running
     # utils.set_available_memory()

--- a/gfw_pixetl/settings/globals.py
+++ b/gfw_pixetl/settings/globals.py
@@ -86,6 +86,11 @@ class Globals(EnvSettings):
         None, description="Endpoint URL for AWS S3 Server (required for Moto)"
     )
 
+    aws_secretsmanager_url: Optional[str] = Field(
+        None,
+        description="Endpoint URL for AWS Secretsmanager Server (required for Moto)",
+    )
+
     @pydantic.validator("db_password", pre=True, always=True)
     def hide_password(cls, v):
         return Secret(v) or None

--- a/gfw_pixetl/utils/aws.py
+++ b/gfw_pixetl/utils/aws.py
@@ -25,7 +25,9 @@ def client_constructor(service: str, endpoint_url: Optional[str] = None):
 get_s3_client = client_constructor("s3", endpoint_url=GLOBALS.aws_endpoint_url)
 get_batch_client = client_constructor("batch")
 get_sts_client = client_constructor("sts")
-get_secret_client = client_constructor("secretsmanager")
+get_secret_client = client_constructor(
+    "secretsmanager", endpoint_url=GLOBALS.aws_secretsmanager_url
+)
 
 
 def download_s3(bucket: str, key: str, dst: str) -> None:

--- a/gfw_pixetl/utils/secrets.py
+++ b/gfw_pixetl/utils/secrets.py
@@ -1,16 +1,13 @@
 import os
 
 from gfw_pixetl import get_module_logger
-from gfw_pixetl.settings.gdal import GDAL_ENV
 from gfw_pixetl.settings.globals import GLOBALS
 from gfw_pixetl.utils.aws import get_secret_client
 
 LOGGER = get_module_logger(__name__)
 
 
-def set_google_application_credentials():
-
-    credential_file = GDAL_ENV["GOOGLE_APPLICATION_CREDENTIALS"]
+def set_google_application_credentials(credential_file):
 
     if not os.path.isfile(credential_file):
         LOGGER.info("GCS key is missing. Try to fetch key from secret manager")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,3 +92,23 @@ def copy_fixtures():
         )
     except FileNotFoundError:
         pass
+
+
+@pytest.fixture(autouse=True)
+def cleanup_tmp():
+
+    yield
+
+    folder = "/tmp"
+    for filename in os.listdir(folder):
+        file_path = os.path.join(folder, filename)
+        try:
+            if (
+                os.path.isfile(file_path) or os.path.islink(file_path)
+            ) and "coverage" not in filename:
+                os.unlink(file_path)
+            elif os.path.isdir(file_path):
+                shutil.rmtree(file_path)
+        except Exception as e:
+            print("Failed to delete %s. Reason: %s" % (file_path, e))
+    open("/tmp/.gitkeep", "a").close()

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+python /usr/local/app/tests/startup.py
+/usr/local/app/wait_for_postgres.sh pytest -vv --cov-report term --cov-report xml:/usr/local/app/tests/cobertura.xml --cov=gfw_pixetl "$@"

--- a/tests/startup.py
+++ b/tests/startup.py
@@ -1,0 +1,27 @@
+from botocore.exceptions import EndpointConnectionError
+from retrying import retry
+
+from gfw_pixetl.settings.globals import GLOBALS
+from gfw_pixetl.utils.aws import get_secret_client
+
+
+def retry_if_endpoint_error(exception) -> bool:
+    """Return True if we should retry, False otherwise."""
+    is_endpoint_error: bool = isinstance(exception, EndpointConnectionError)
+    return is_endpoint_error
+
+
+@retry(
+    retry_on_exception=retry_if_endpoint_error,
+    stop_max_attempt_number=5,
+    wait_fixed=2000,
+)
+def add_secrets():
+    secret_client = get_secret_client()
+    secret_client.create_secret(
+        Name=GLOBALS.aws_gcs_key_secret_arn, SecretString="foosecret"
+    )
+
+
+if __name__ == "__main__":
+    add_secrets()

--- a/tests/test_pixetl.py
+++ b/tests/test_pixetl.py
@@ -1,13 +1,9 @@
 import os
 from unittest import mock
 
-from moto import mock_secretsmanager
-
 from gfw_pixetl.models.pydantic import LayerModel
 from gfw_pixetl.pipes import RasterPipe
 from gfw_pixetl.pixetl import pixetl
-from gfw_pixetl.settings.globals import GLOBALS
-from gfw_pixetl.utils.aws import get_secret_client
 from tests import minimal_layer_dict
 
 os.environ["ENV"] = "test"
@@ -24,12 +20,7 @@ RASTER_LAYER_DEF = LayerModel.parse_obj(LAYER_DICT)
 SUBSET = ["10N_010E"]
 
 
-@mock_secretsmanager
 def test_pixetl():
-    secret_client = get_secret_client()
-    secret_client.create_secret(
-        Name=GLOBALS.aws_gcs_key_secret_arn, SecretString="foosecret"
-    )
 
     cwd = os.getcwd()
 

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -3,20 +3,18 @@ import os
 from moto import mock_secretsmanager
 
 from gfw_pixetl.settings.gdal import GDAL_ENV
-from gfw_pixetl.settings.globals import GLOBALS
-from gfw_pixetl.utils.aws import get_secret_client
 from gfw_pixetl.utils.secrets import set_google_application_credentials
 
 
 @mock_secretsmanager
 def test_gcs_secret():
     secret = "foosecret"  # pragma: allowlist secret
-    secret_client = get_secret_client()
-    secret_client.create_secret(
-        Name=GLOBALS.aws_gcs_key_secret_arn, SecretString=secret
-    )
     credential_file = GDAL_ENV["GOOGLE_APPLICATION_CREDENTIALS"]
 
+    # Secret should already be set during initialization
+    _secret_set(credential_file, secret)
+
+    # lets remove everything and try to set it again
     if os.path.isfile(credential_file):
         os.remove(credential_file)
     if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
@@ -24,7 +22,11 @@ def test_gcs_secret():
 
     assert not os.path.isfile(credential_file)
 
-    set_google_application_credentials()
+    set_google_application_credentials(credential_file)
+    _secret_set(credential_file, secret)
+
+
+def _secret_set(credential_file, secret):
     assert os.path.isfile(credential_file)
     with open(credential_file) as src:
         data = src.read()

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -163,7 +163,7 @@ def test_gradient_symbology():
 
     tile = Tile("01N_001E", layer.grid, layer)
 
-    test_file = os.path.join(TILE.tmp_dir, "test_gradient_color.tif")
+    test_file = os.path.join(tile.tmp_dir, "test_gradient_color.tif")
     shutil.copyfile(TILE_4_PATH, test_file)
 
     # monkey patch method to point to test file
@@ -215,7 +215,7 @@ def test_discrete_symbology():
 
     tile = Tile("01N_001E", layer.grid, layer)
 
-    test_file = os.path.join(TILE.tmp_dir, "test_gradient_color.tif")
+    test_file = os.path.join(tile.tmp_dir, "test_gradient_color.tif")
     shutil.copyfile(TILE_4_PATH, test_file)
 
     # monkey patch method to point to test file


### PR DESCRIPTION
Signed-off-by: Thomas Maschler <tmaschler@wri.org>

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 
- Cannot test pixetl with data api due to aws secretsmanager dependency

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- add second moto server for secretsmanager
- set secrets during initialization
- clean up after tests

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
