### PR TITLE
Union, filter pieces of MultiPolygons before taking intersection

### DIFF
--- a/gfw_pixetl/utils/utils.py
+++ b/gfw_pixetl/utils/utils.py
@@ -1,11 +1,12 @@
 import datetime
 import os
 from math import floor
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Union
 
 from pyproj import CRS, Transformer
 from rasterio.windows import Window
-from shapely.geometry import MultiPolygon
+from shapely.geometry import MultiPolygon, Polygon
+from shapely.ops import unary_union
 
 from gfw_pixetl import get_module_logger
 from gfw_pixetl.models.types import Bounds
@@ -92,16 +93,26 @@ def world_bounds(crs: CRS) -> Bounds:
 
 
 def intersection(a: MultiPolygon, b: Optional[MultiPolygon]) -> Optional[MultiPolygon]:
-    if b:
-        geom = None
+    geom: Optional[MultiPolygon] = None
+    if not b:
+        geom = a
+
+    else:
         _geom = a.intersection(b)
+        # Sometimes the intersection results in a GeometryCollection and
+        # includes things like LineStrings (like when two polygons both share
+        # an edge and overlap elsewhere), which we don't care about. Filter
+        # that stuff out to output a plain MultiPolygon.
         if _geom.type == "GeometryCollection":
+            geom_pieces: List[Union[MultiPolygon, Polygon]] = list()
             for g in _geom.geoms:
                 if g.type == "MultiPolygon" or g.type == "Polygon":
-                    geom = g
-                    break
+                    geom_pieces.append(g)
+            geom = unary_union(geom_pieces)
         else:
             geom = _geom
-        return geom
-    else:
-        return a
+
+    if geom.type == "Polygon":
+        geom = MultiPolygon([geom])
+
+    return geom


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- We were only saving the first Polygon/MultiPolygon from a GeometryCollection when taking the intersection of two MultiPolygons, resulting in some tiles being erroneously skipped as empty

Issue Number: GTC-1236


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The pieces of a GeometryCollection are filtered and then unioned after taking the intersection of two MultiPolygons
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
