### PR TITLE
Drop requirement for calc string when not actually required

### DIFF
--- a/gfw_pixetl/models/pydantic.py
+++ b/gfw_pixetl/models/pydantic.py
@@ -64,10 +64,6 @@ class LayerModel(BaseModel):
     def validate_source_uri(cls, v, values, **kwargs):
         if values.get("source_type") == SourceType.raster:
             assert v, "Raster source types require source_uri"
-            if len(v) > 1:
-                assert values.get(
-                    "calc"
-                ), "More than one source_uri requires a calc string"
         else:
             assert not v, "Only raster source type require source_uri"
         return v
@@ -79,14 +75,6 @@ class LayerModel(BaseModel):
                 values.get("band_count")
             ), f"Length of no data list ({v}) must match band count ({values.get('band_count')})."
             assert len(set(v)) == 1, "No data values must be the same for all bands"
-        return v
-
-    @validator("band_count")
-    def validate_band_count(cls, v, values, **kwargs):
-        if v > 1:
-            assert values.get(
-                "calc"
-            ), "Output raster with more than one band requires a calc string"
         return v
 
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 module "container_registry" {
-  source     = "git::https://github.com/wri/gfw-terraform-modules.git//terraform/modules/container_registry?ref=v0.3.0"
+  source     = "git::https://github.com/wri/gfw-terraform-modules.git//terraform/modules/container_registry?ref=v0.4.2.2"
   image_name = "${local.project}${local.name_suffix}"
   root_dir   = "../${path.root}"
 }
@@ -16,7 +16,7 @@ module "container_registry" {
 
 
 module "compute_environment_ephemeral_storage" {
-  source               = "git::https://github.com/wri/gfw-terraform-modules.git//terraform/modules/compute_environment?ref=v0.3.0"
+  source               = "git::https://github.com/wri/gfw-terraform-modules.git//terraform/modules/compute_environment?ref=v0.4.2.2"
   project              = local.project
   key_pair             = data.terraform_remote_state.core.outputs.key_pair_tmaschler_gfw
   subnets              = data.terraform_remote_state.core.outputs.private_subnet_ids

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -116,19 +116,6 @@ def test_vector_layer():
     assert layer.order == "desc"
 
 
-def test_multi_source_layer_no_calc():
-    layer_dict = {
-        **minimal_layer_dict,
-        "source_uri": [
-            f"s3://{BUCKET}/{GEOJSON_NAME}",
-            f"s3://{BUCKET}/{GEOJSON_2_NAME}",
-        ],
-    }
-
-    with pytest.raises(ValidationError):
-        layers.layer_factory(LayerModel.parse_obj(layer_dict))
-
-
 def test_multi_source_layer():
     layer_dict = {
         **minimal_layer_dict,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -166,40 +166,6 @@ def test_layer_model_multi_band_no_data_different():
         )
 
 
-def test_layer_model_multi_band_no_calc_multi_output():
-    # no calc, multi band output
-    with pytest.raises(ValidationError):
-        LayerModel(
-            dataset="test",
-            version="v1.1.1",
-            source_type=SourceType.raster,
-            pixel_meaning="test",
-            data_type=DataTypeEnum.uint8,
-            nbits=6,
-            no_data=0,
-            band_count=3,
-            grid="10/40000",
-            source_uri=["s3://test/tiles.geojson"],
-        )
-
-
-def test_layer_model_multi_band_no_calc_multi_input():
-    # no calc,  multi band input
-    with pytest.raises(ValidationError):
-        LayerModel(
-            dataset="test",
-            version="v1.1.1",
-            source_type=SourceType.raster,
-            pixel_meaning="test",
-            data_type=DataTypeEnum.uint8,
-            nbits=6,
-            no_data=0,
-            band_count=1,
-            grid="10/40000",
-            source_uri=["s3://test/tiles.geojson", "s3://test/tiles.geojson"],
-        )
-
-
 def test_layer_model_multi_band_output_multi_no_data():
     LayerModel(
         dataset="test",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
* A calc string is required if either there are multiple output bands or multiple input src_uris. But this is an artificial restriction, the code will be perfectly happy stacking the input band(s) without transformation, which sometimes is what you want. In that case having to specify a calc string is annoying.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- If what one wants is the input band(s) passed through without modification, one can omit a calc string for multi-band input/output situations.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
