### PR TITLE
Add 10km grid; break-up and isolate filter_target_tiles tests

### DIFF
--- a/gfw_pixetl/grids/grid_factory.py
+++ b/gfw_pixetl/grids/grid_factory.py
@@ -19,6 +19,7 @@ grids: Dict[str, Grid] = {
     "8/32000": LatLngGrid(8, 32000),  # UMD alerts, ~30m pixel, data cube optimized Grid
     "90/27008": LatLngGrid(90, 27008),  # VIIRS Fire alerts, ~375m pixel
     "90/9984": LatLngGrid(90, 9984),  # MODIS Fire alerts, ~1000m pixel
+    "90/998": LatLngGrid(90, 998),  # TCL Drivers ~10km pixel?
 }
 
 for zoom in range(0, 23):

--- a/gfw_pixetl/grids/grid_factory.py
+++ b/gfw_pixetl/grids/grid_factory.py
@@ -19,7 +19,7 @@ grids: Dict[str, Grid] = {
     "8/32000": LatLngGrid(8, 32000),  # UMD alerts, ~30m pixel, data cube optimized Grid
     "90/27008": LatLngGrid(90, 27008),  # VIIRS Fire alerts, ~375m pixel
     "90/9984": LatLngGrid(90, 9984),  # MODIS Fire alerts, ~1000m pixel
-    "90/998": LatLngGrid(90, 998),  # TCL Drivers ~10km pixel?
+    "90/1008": LatLngGrid(90, 1008),  # TCL Drivers ~10km pixel?
 }
 
 for zoom in range(0, 23):

--- a/gfw_pixetl/pipes/pipe.py
+++ b/gfw_pixetl/pipes/pipe.py
@@ -90,7 +90,7 @@ class Pipe(ABC):
     @staticmethod
     @stage(workers=GLOBALS.num_processes)
     def filter_target_tiles(tiles: Iterator[Tile], overwrite: bool) -> Iterator[Tile]:
-        """Don't process tiles if they already exists in target location,
+        """Don't process tiles if they already exist in target location,
         unless overwrite is set to True."""
         for tile in tiles:
             if (

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -47,16 +47,20 @@ def test_filter_subset_tiles(PIPE):
     assert i == len(SUBSET_1x1)
 
 
-def test_filter_target_tiles(PIPE, _upload_pipe_fixtures):
+def test_filter_target_tiles_all_existing_no_overwrite(PIPE, _upload_pipe_fixtures):
     tiles = _get_subset_tiles(PIPE)
-    pipe = tiles | PIPE.filter_target_tiles(overwrite=False)
-    i = 0
-    for tile in pipe.results():
-        if tile.status == "pending":
-            i += 1
-            assert isinstance(tile, Tile)
-    assert i == 0
+    with mock.patch.object(Destination, "exists", return_value=True):
+        pipe = tiles | PIPE.filter_target_tiles(overwrite=False)
+        i = 0
+        for tile in pipe.results():
+            if tile.status == "pending":
+                i += 1
+                assert isinstance(tile, Tile)
+        assert i == 0
 
+
+def test_filter_target_tiles_no_existing_no_overwrite(PIPE, _upload_pipe_fixtures):
+    tiles = _get_subset_tiles(PIPE)
     with mock.patch.object(Destination, "exists", return_value=False):
         pipe = tiles | PIPE.filter_target_tiles(overwrite=False)
         i = 0
@@ -66,14 +70,21 @@ def test_filter_target_tiles(PIPE, _upload_pipe_fixtures):
                 assert isinstance(tile, Tile)
         assert i == 4
 
-    pipe = tiles | PIPE.filter_target_tiles(overwrite=True)
-    i = 0
-    for tile in pipe.results():
-        if tile.status == "pending":
-            i += 1
-            assert isinstance(tile, Tile)
-    assert i == 4
 
+def test_filter_target_tiles_all_existing_overwrite(PIPE, _upload_pipe_fixtures):
+    tiles = _get_subset_tiles(PIPE)
+    with mock.patch.object(Destination, "exists", return_value=True):
+        pipe = tiles | PIPE.filter_target_tiles(overwrite=True)
+        i = 0
+        for tile in pipe.results():
+            if tile.status == "pending":
+                i += 1
+                assert isinstance(tile, Tile)
+        assert i == 4
+
+
+def test_filter_target_tiles_no_existing_overwrite(PIPE, _upload_pipe_fixtures):
+    tiles = _get_subset_tiles(PIPE)
     with mock.patch.object(Destination, "exists", return_value=False):
         pipe = tiles | PIPE.filter_target_tiles(overwrite=True)
         i = 0
@@ -83,13 +94,17 @@ def test_filter_target_tiles(PIPE, _upload_pipe_fixtures):
                 assert isinstance(tile, Tile)
         assert i == 4
 
-    pipe = tiles | PIPE.filter_target_tiles(overwrite=False)
-    i = 0
-    for tile in pipe.results():
-        if tile.status == "existing":
-            i += 1
-            assert isinstance(tile, Tile)
-    assert i == 4
+
+def test_filter_target_tiles_all_existing_no_overwrite_positive(PIPE, _upload_pipe_fixtures):
+    tiles = _get_subset_tiles(PIPE)
+    with mock.patch.object(Destination, "exists", return_value=True):
+        pipe = tiles | PIPE.filter_target_tiles(overwrite=False)
+        i = 0
+        for tile in pipe.results():
+            if tile.status == "existing":
+                i += 1
+                assert isinstance(tile, Tile)
+        assert i == 4
 
 
 def test_upload_file(PIPE):


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is no grid suitable for 10km resolution

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- There is a new 90/1008 grid suitable for 10km resolution datasets
- Tests were inexplicably failing, so I fixed them
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
