### PR TITLE
Catch GDAL command errors when exit code is 0

### DIFF
--- a/gfw_pixetl/errors.py
+++ b/gfw_pixetl/errors.py
@@ -32,12 +32,21 @@ class MissingGCSKeyError(Exception):
     pass
 
 
-def retry_if_none_type_error(exception) -> bool:
-    """Return True if we should retry (in this case when it's an IOError),
+class PGConnectionInterruptedError(Exception):
+    pass
+
+
+def retry_on_gdal_errors(exception) -> bool:
+    """Return True if we should retry (in this case when it's an IOError or connection error),
     False otherwise."""
     is_none_type_error: bool = isinstance(exception, GDALNoneTypeError)
+    is_connection_error: bool = isinstance(exception, PGConnectionInterruptedError)
+
     if is_none_type_error:
         LOGGER.warning("GDALNoneType exception - RETRY")
+    elif is_connection_error:
+        LOGGER.warning("PGConnectionInterruptedError exception - RETRY")
+
     return is_none_type_error
 
 

--- a/gfw_pixetl/errors.py
+++ b/gfw_pixetl/errors.py
@@ -47,7 +47,7 @@ def retry_on_gdal_errors(exception) -> bool:
     elif is_connection_error:
         LOGGER.warning("PGConnectionInterruptedError exception - RETRY")
 
-    return is_none_type_error
+    return is_none_type_error or is_connection_error
 
 
 def retry_if_volume_not_ready(exception) -> bool:

--- a/gfw_pixetl/utils/gdal.py
+++ b/gfw_pixetl/utils/gdal.py
@@ -17,7 +17,7 @@ from gfw_pixetl.errors import (
     GDALNoneTypeError,
     MissingGCSKeyError,
     retry_if_missing_gcs_key_error,
-    retry_if_none_type_error,
+    retry_on_gdal_errors,
 )
 from gfw_pixetl.models.named_tuples import InputBandElement
 from gfw_pixetl.models.pydantic import Band, BandStats, Histogram, Metadata
@@ -106,7 +106,7 @@ def just_copy_geotiff(src_uri, dst_uri, profile):
 
 
 @retry(
-    retry_on_exception=retry_if_none_type_error,
+    retry_on_exception=retry_on_gdal_errors,
     stop_max_attempt_number=7,
     wait_fixed=2000,
 )
@@ -145,6 +145,8 @@ def run_gdal_subcommand(
             raise GDALAWSConfigError(e)
         elif "ERROR 3: Load json file" in e or "GOOGLE_APPLICATION_CREDENTIALS" in e:
             raise MissingGCSKeyError(e)
+        elif "ERROR 1: SSL SYSCALL error" in e:
+            raise PGConnectionInterruptedError(e)
         else:
             raise GDALError(e)
 

--- a/gfw_pixetl/utils/gdal.py
+++ b/gfw_pixetl/utils/gdal.py
@@ -132,7 +132,8 @@ def run_gdal_subcommand(
         o = str(o_byte)
         e = str(e_byte)
 
-    if p.returncode != 0:
+    # sometimes GDAL returns exit code 0 even though there was actually an error
+    if p.returncode != 0 or "error" in e.lower():
         if p.returncode < 0:
             raise SubprocessKilledError()
         elif not e:

--- a/gfw_pixetl/utils/gdal.py
+++ b/gfw_pixetl/utils/gdal.py
@@ -16,6 +16,7 @@ from gfw_pixetl.errors import (
     GDALError,
     GDALNoneTypeError,
     MissingGCSKeyError,
+    PGConnectionInterruptedError,
     retry_if_missing_gcs_key_error,
     retry_on_gdal_errors,
 )

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,7 +18,7 @@ module "container_registry" {
 module "compute_environment_ephemeral_storage" {
   source               = "git::https://github.com/wri/gfw-terraform-modules.git//terraform/modules/compute_environment?ref=v0.4.2.2"
   project              = local.project
-  key_pair             = data.terraform_remote_state.core.outputs.key_pairs["dmannarino_gfw"]
+  key_pair             = data.terraform_remote_state.core.outputs.key_pairs["dmannarino_gfw"].key_name
   subnets              = data.terraform_remote_state.core.outputs.private_subnet_ids
   tags                 = local.tags
   security_group_ids   = [data.terraform_remote_state.core.outputs.default_security_group_id, data.terraform_remote_state.core.outputs.postgresql_security_group_id]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,7 +18,7 @@ module "container_registry" {
 module "compute_environment_ephemeral_storage" {
   source               = "git::https://github.com/wri/gfw-terraform-modules.git//terraform/modules/compute_environment?ref=v0.4.2.2"
   project              = local.project
-  key_pair             = data.terraform_remote_state.core.outputs.key_pair_tmaschler_gfw
+  key_pair             = data.terraform_remote_state.core.outputs.key_pairs["dmannarino_gfw"]
   subnets              = data.terraform_remote_state.core.outputs.private_subnet_ids
   tags                 = local.tags
   security_group_ids   = [data.terraform_remote_state.core.outputs.default_security_group_id, data.terraform_remote_state.core.outputs.postgresql_security_group_id]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ from dateutil.tz import tzutc
 from pyproj import CRS
 from shapely.geometry import MultiPolygon, Polygon
 
-from gfw_pixetl.errors import GDALError, GDALNoneTypeError
+from gfw_pixetl.errors import GDALError, GDALNoneTypeError, PGConnectionInterruptedError
 from gfw_pixetl.settings.globals import GLOBALS
 from gfw_pixetl.utils.cwd import set_cwd
 from gfw_pixetl.utils.gdal import create_vrt, run_gdal_subcommand
@@ -148,6 +148,13 @@ def test_run_gdal_subcommand():
         assert False
     except GDALError as e:
         assert "ERROR" in str(e)
+
+    try:
+        cmd = ["/bin/bash", "-c", ">&2 echo ERROR 1: SSL SYSCALL error"]
+        run_gdal_subcommand(cmd)
+        assert False
+    except PGConnectionInterruptedError as e:
+        assert "ERROR 1: SSL SYSCALL error" in str(e)
 
 
 def test_intersection():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ from dateutil.tz import tzutc
 from pyproj import CRS
 from shapely.geometry import MultiPolygon, Polygon
 
-from gfw_pixetl.errors import GDALNoneTypeError
+from gfw_pixetl.errors import GDALError, GDALNoneTypeError
 from gfw_pixetl.settings.globals import GLOBALS
 from gfw_pixetl.utils.cwd import set_cwd
 from gfw_pixetl.utils.gdal import create_vrt, run_gdal_subcommand
@@ -137,8 +137,16 @@ def test_run_gdal_subcommand():
     try:
         cmd = ["/bin/bash", "-c", "exit 1"]
         run_gdal_subcommand(cmd)
+        assert False
     except GDALNoneTypeError as e:
         assert str(e) == ""
+
+    try:
+        cmd = ["/bin/bash", "-c", "echo ERROR"]
+        run_gdal_subcommand(cmd)
+        assert False
+    except GDALError as e:
+        assert str(e) == "ERROR"
 
 
 def test_intersection():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,11 +142,12 @@ def test_run_gdal_subcommand():
         assert str(e) == ""
 
     try:
-        cmd = ["/bin/bash", "-c", "echo ERROR"]
+        # write to stderr
+        cmd = ["/bin/bash", "-c", ">&2 echo ERROR"]
         run_gdal_subcommand(cmd)
         assert False
     except GDALError as e:
-        assert str(e) == "ERROR"
+        assert "ERROR" in str(e)
 
 
 def test_intersection():


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type


Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
GDAL subcommands are marked as succeeded if their exit code is 0. However, sometimes GDAL commands seem to return exit code 0, even though they write there was an error to stderr (e.g. gdal_rasterize). 


## What is the new behavior?
Check stderr of GDAL subcommands and don't mark as success if "error" is in the output.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


