### PR TITLE
Log (instead of throw an exception) when we detect the word error in stderr

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = aenum,affine,boto3,botocore,click,dateutil,geojson,google,moto,numpy,parallelpipe,psutil,psycopg2,pydantic,pyproj,pytest,rasterio,retrying,setuptools,shapely,sqlalchemy,yaml
+known_third_party = _pytest,aenum,affine,boto3,botocore,click,dateutil,geojson,google,moto,numpy,parallelpipe,psutil,psycopg2,pydantic,pyproj,pytest,rasterio,retrying,setuptools,shapely,sqlalchemy,yaml

--- a/gfw_pixetl/utils/gdal.py
+++ b/gfw_pixetl/utils/gdal.py
@@ -133,8 +133,15 @@ def run_gdal_subcommand(
         o = str(o_byte)
         e = str(e_byte)
 
-    # sometimes GDAL returns exit code 0 even though there was actually an error
-    if p.returncode != 0 or "error" in e.lower():
+    # Sometimes GDAL returns exit code 0 even though there was actually an error
+    # It's hard to tell what is and what isn't though, so log as a warning
+    if p.returncode == 0 and "error" in e.lower():
+        LOGGER.warning(
+            'Word "error" found in stderr but exit code was 0. '
+            f'command: {cmd} '
+            f'stderr: {e}'
+        )
+    elif p.returncode != 0:
         if p.returncode < 0:
             raise SubprocessKilledError()
         elif not e:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -151,14 +151,14 @@ def test_run_gdal_subcommand_zero_exit_with_stderr():
     assert run_gdal_subcommand(cmd) == ("test\n", "")
 
     logger = logging.getLogger()
-    logger.warning = Mock(logger.warning)
-    MonkeyPatch().setattr(gfw_pixetl.utils.gdal, "get_module_logger", lambda: logger)
+    logger.warning = Mock()
+    MonkeyPatch().setattr(gfw_pixetl.utils.gdal, "LOGGER", logger)
 
     # write to stderr
-    cmd = ["/bin/bash", "-c", ">&2 echo ERROR"]
+    cmd = ["/bin/bash", "-c", ">&2 echo ERROR 1: SSL SYSCALL"]
     o, e = run_gdal_subcommand(cmd)
 
-    assert "ERROR" in e
+    assert "ERROR 1: SSL SYSCALL" in str(e)
     assert logger.warning.called is True
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,15 @@
+import logging
 import os
 from datetime import datetime
+from unittest.mock import Mock
 
 import rasterio
 from dateutil.tz import tzutc
 from pyproj import CRS
 from shapely.geometry import MultiPolygon, Polygon
 
-from gfw_pixetl.errors import GDALError, GDALNoneTypeError, PGConnectionInterruptedError
+import gfw_pixetl.utils.gdal
+from gfw_pixetl.errors import GDALNoneTypeError
 from gfw_pixetl.settings.globals import GLOBALS
 from gfw_pixetl.utils.cwd import set_cwd
 from gfw_pixetl.utils.gdal import create_vrt, run_gdal_subcommand
@@ -18,6 +21,7 @@ from gfw_pixetl.utils.utils import (
     intersection,
     world_bounds,
 )
+from _pytest.monkeypatch import MonkeyPatch
 from tests.conftest import BUCKET, TILE_1_NAME, TILE_2_NAME
 from tests.utils import compare_multipolygons
 
@@ -130,7 +134,7 @@ def test_get_aws_s3_endpoint():
     assert get_aws_s3_endpoint("motoserver:5000") == "motoserver:5000"
 
 
-def test_run_gdal_subcommand():
+def test_run_gdal_subcommand_nonzero_exit():
     cmd = ["/bin/bash", "-c", "echo test"]
     assert run_gdal_subcommand(cmd) == ("test\n", "")
 
@@ -141,20 +145,21 @@ def test_run_gdal_subcommand():
     except GDALNoneTypeError as e:
         assert str(e) == ""
 
-    try:
-        # write to stderr
-        cmd = ["/bin/bash", "-c", ">&2 echo ERROR"]
-        run_gdal_subcommand(cmd)
-        assert False
-    except GDALError as e:
-        assert "ERROR" in str(e)
 
-    try:
-        cmd = ["/bin/bash", "-c", ">&2 echo ERROR 1: SSL SYSCALL error"]
-        run_gdal_subcommand(cmd)
-        assert False
-    except PGConnectionInterruptedError as e:
-        assert "ERROR 1: SSL SYSCALL error" in str(e)
+def test_run_gdal_subcommand_zero_exit_with_stderr():
+    cmd = ["/bin/bash", "-c", "echo test"]
+    assert run_gdal_subcommand(cmd) == ("test\n", "")
+
+    logger = logging.getLogger()
+    logger.warning = Mock(logger.warning)
+    MonkeyPatch().setattr(gfw_pixetl.utils.gdal, "get_module_logger", lambda: logger)
+
+    # write to stderr
+    cmd = ["/bin/bash", "-c", ">&2 echo ERROR"]
+    o, e = run_gdal_subcommand(cmd)
+
+    assert "ERROR" in e
+    assert logger.warning.called is True
 
 
 def test_intersection():


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Running a GDAL command which outputs the word "error" to stderr (even when the command's exit code is 0) results in the job failing. This is bad because even retryable errors (HTTP 429s from AWS, for example) result in failures.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Log occurrences of "error" instead of failing. This increases visibility of the problem but doesn't cause the job to fail on retryable errors.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
A GDAL bug will be logged for the utility originally in mind for this condition.