### PR TITLE
Cause gdal job fail from SSL SYSCALL error

### DIFF
--- a/gfw_pixetl/utils/gdal.py
+++ b/gfw_pixetl/utils/gdal.py
@@ -136,19 +136,18 @@ def run_gdal_subcommand(
     # Sometimes GDAL returns exit code 0 even though there was actually an error.
     # Raise a hard error if it is an SSL SYSCALL error, since that possibly means a
     # database connection was dropped (and so a tile rasterization might be
-    # incomplete).
-    if p.returncode == 0 and "ERROR 1: SSL SYSCALL error" in e:
-        raise PGConnectionInterruptedError(e)
-
-    # Otherwise, log a warning, but don't raise an error.
-    if p.returncode == 0 and "error" in e.lower():
-        LOGGER.warning(
-            'Word "error" found in stderr but exit code was 0. '
-            f'command: {cmd} '
-            f'stderr: {e}'
-        )
+    # incomplete). Otherwise, log a warning, but don't raise an error.
+    if p.returncode == 0:
+        if "ERROR 1: SSL SYSCALL error" in e:
+            raise PGConnectionInterruptedError(e)
+        elif "error" in e.lower():
+            LOGGER.warning(
+                'Word "error" found in stderr but exit code was 0. '
+                f'command: {cmd} '
+                f'stderr: {e}'
+            )
     # Raise an error if the exit code is non-zero.
-    elif p.returncode != 0:
+    else:
         if p.returncode < 0:
             raise SubprocessKilledError()
         elif not e:


### PR DESCRIPTION
Cause gdal job fail from SSL SYSCALL error

GDAL sometimes has errors, but still returns exit code 0. We are printint a warning log in this case.

However, we need to cause a failure if there is an SSL SYSCALL error in the log, since that could indicate a loss of connection of the database. That could mean that a tile rasterization has been stopped early, so the tile will be incorrect (since not all polygons will have been rasterized).
